### PR TITLE
Avoid "you are on your own" warning on success

### DIFF
--- a/NitroxServer/IpLogger.cs
+++ b/NitroxServer/IpLogger.cs
@@ -89,8 +89,7 @@ namespace NitroxServer
             else
             {
                 Log.Warn("Could not get your external IP. You are on your own...");
-            }
-            
+            }            
         }
     }
 }

--- a/NitroxServer/IpLogger.cs
+++ b/NitroxServer/IpLogger.cs
@@ -86,8 +86,11 @@ namespace NitroxServer
             {
                 Log.Info($"If using port forwarding, use this IP: {e.Result}");
             }
-
-            Log.Warn("Could not get your external IP. You are on your own...");
+            else
+            {
+                Log.Warn("Could not get your external IP. You are on your own...");
+            }
+            
         }
     }
 }


### PR DESCRIPTION
I always got both messages:

```
If using port forwarding, use this IP: xxx.xxx.xxx.xxx
Could not get your external IP. You are on your own...
```